### PR TITLE
MENEX-82: Fix orbitDb Database Syncing

### DIFF
--- a/database/package-lock.json
+++ b/database/package-lock.json
@@ -9,6 +9,7 @@
         "@chainsafe/libp2p-noise": "^16.0.0",
         "@helia/block-brokers": "^4.0.2",
         "@libp2p/identify": "^3.0.14",
+        "@libp2p/mdns": "^11.0.16",
         "@libp2p/mplex": "^11.0.16",
         "@libp2p/tcp": "^10.0.14",
         "@libp2p/websockets": "^9.1.1",

--- a/database/package.json
+++ b/database/package.json
@@ -5,6 +5,7 @@
     "@chainsafe/libp2p-noise": "^16.0.0",
     "@helia/block-brokers": "^4.0.2",
     "@libp2p/identify": "^3.0.14",
+    "@libp2p/mdns": "^11.0.16",
     "@libp2p/mplex": "^11.0.16",
     "@libp2p/tcp": "^10.0.14",
     "@libp2p/websockets": "^9.1.1",

--- a/database/userPublicKeys.js
+++ b/database/userPublicKeys.js
@@ -1,6 +1,6 @@
 import { getDatabase} from './orbitdb-service.js';
 
-const databaseAddress = '/orbitdb/zdpuAxcSKQy1yqfX6WF9tpwUSTLSTJKcb5GuT4zkjQtDpFGCE'
+const databaseAddress = '/orbitdb/zdpuAkuM6QhiPXiBG4RArwpHGSPYtEUPKQVVE9hKr7adaeAB2'
 let publicKeysDB = null;
 
 export async function getPublicKeysDB() {


### PR DESCRIPTION
The fix for orbitDB syncing was unsuccessful. Libp2p appears to be working correctly as host and secondary machines are able to connect as peers. I don't show data replication events firing. Secondary machine crashes with the error "Key ... not allowed to write to log". I believe this is an issue with the orbitDB accessController not correctly setting write permissions for the database. 

I want to merge the work done so far on the issue, but move forward to other parts of meNexus. I will come back and solve this later.